### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -153,8 +153,8 @@ def scrape_term(term, url)
   data.count
 end
 
-# Start with a clean slate…
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+# Start with a clean slate
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 terms.each do |term, url|
   added = scrape_term(term, url)
   puts "Term #{term}: #{added}"


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: https://github.com/everypolitician/everypolitician/issues/593